### PR TITLE
Refactor EMF codegen plugin

### DIFF
--- a/emf/codegen.maven.example/ecore.loadpackage/model/runtime.ecore
+++ b/emf/codegen.maven.example/ecore.loadpackage/model/runtime.ecore
@@ -7,6 +7,7 @@
     <details key="fileExtensions" value="runtime"/>
     <details key="resource" value="XMI"/>
     <details key="loadInitialization" value="true"/>
+    <details key="literalsInterface" value="true"/>
     <details key="copyrightText" value="Copyright (c) 2025 Contributors to the Eclipse Foundation.&#xA;&#xA;This program and the accompanying materials are made&#xA;available under the terms of the Eclipse Public License 2.0&#xA;which is available at https://www.eclipse.org/legal/epl-2.0/&#xA;&#xA;SPDX-License-Identifier: EPL-2.0"/>
     <details key="documentation" value="Runtime model demonstrating packageFilename field generation for runtime model loading."/>
   </eAnnotations>

--- a/emf/codegen.maven.example/ecore.loadpackage/pom.xml
+++ b/emf/codegen.maven.example/ecore.loadpackage/pom.xml
@@ -55,15 +55,6 @@
   </dependencies>
 
   <build>
-    <!-- Include .ecore files from generated-sources as resources (for loadInitialization=true) -->
-    <resources>
-      <resource>
-        <directory>target/generated-sources/emf</directory>
-        <includes>
-          <include>**/*.ecore</include>
-        </includes>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <groupId>org.eclipse.daanse</groupId>
@@ -76,21 +67,12 @@
             </goals>
             <configuration>
               <!--
-                This example demonstrates:
-                1. packageFilename field generation for runtime model loading
-                2. The plugin post-processing updates packageFilename from
-                   "runtime.ecore" to "model/runtime.ecore"
-                3. Model files in a model/ folder at project root
+                This example demonstrates loadInitialization=true mode:
+                - EMF generates packageFilename = "runtime.ecore" (relative path)
+                - EMF copies the ecore to the impl directory
+                - The ecore annotation in the source model enables loadInitialization
               -->
               <ecoreFile>model/runtime.ecore</ecoreFile>
-              <outputDirectory>target/generated-sources/emf</outputDirectory>
-              <ecoreBundleLocation>model/runtime.ecore</ecoreBundleLocation>
-
-              <!-- @EPackage annotation configuration -->
-              <includeGenModelAttr>false</includeGenModelAttr>
-              <includeGenModelSourceLocationsAttr>false</includeGenModelSourceLocationsAttr>
-              <includeEcoreAttr>true</includeEcoreAttr>
-              <includeEcoreSourceLocationsAttr>false</includeEcoreSourceLocationsAttr>
             </configuration>
           </execution>
         </executions>

--- a/emf/codegen.maven.example/ecore.loadpackage/src/test/java/org/eclipse/daanse/example/runtime/integration/PackageFilenameTest.java
+++ b/emf/codegen.maven.example/ecore.loadpackage/src/test/java/org/eclipse/daanse/example/runtime/integration/PackageFilenameTest.java
@@ -20,12 +20,13 @@ import org.junit.jupiter.api.Test;
 class PackageFilenameTest {
 
     @Test
-    void packageFilenameHasModelPrefix() throws Exception {
+    void packageFilenameIsRelative() throws Exception {
         Class<?> implClass = RuntimePackageImpl.class;
         Field field = implClass.getDeclaredField("packageFilename");
         field.setAccessible(true);
         Object instance = RuntimePackage.eINSTANCE;
         String value = (String) field.get(instance);
-        assertEquals("/model/runtime.ecore", value);
+        // EMF generates relative path - ecore is in same directory as impl class
+        assertEquals("runtime.ecore", value);
     }
 }


### PR DESCRIPTION
handle packageFilename correctly and update test cases for relative paths and literal generation
