### PR TITLE
Fix cross-module EPackage state leak in EmfGenerateMojo

### DIFF
--- a/emf/codegen.maven.example/ecore.dependencies.subpackages.consumer.subpackages/model/consumer.ecore
+++ b/emf/codegen.maven.example/ecore.dependencies.subpackages.consumer.subpackages/model/consumer.ecore
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="consumer"
+    nsURI="http://daanse.eclipse.org/example/consumer.subpackages" nsPrefix="consumer">
+  <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+    <details key="basePackage" value="org.eclipse.daanse.example.consumer"/>
+    <details key="prefix" value="Consumer"/>
+  </eAnnotations>
+  <eSubpackages name="processing" nsURI="http://daanse.eclipse.org/example/consumer.subpackages/processing"
+      nsPrefix="processing">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="basePackage" value="org.eclipse.daanse.example.consumer"/>
+      <details key="prefix" value="Processing"/>
+    </eAnnotations>
+    <eClassifiers xsi:type="ecore:EClass" name="ProcessingRecord">
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="name"
+          eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+      <!-- Reference into nested.ecore's a/Alpha (one subpackage deep).
+           URI part = root nsURI; fragment is the path FROM the resource root
+           (nested EPackage), navigating into subpackages.  -->
+      <eStructuralFeatures xsi:type="ecore:EReference" name="seedAlpha"
+          eType="ecore:EClass http://daanse.eclipse.org/example/nested#//a/Alpha"/>
+      <!-- Reference into nested.ecore's a/b/Beta (two subpackages deep) -->
+      <eStructuralFeatures xsi:type="ecore:EReference" name="seedBeta"
+          eType="ecore:EClass http://daanse.eclipse.org/example/nested#//a/b/Beta"
+          containment="true"/>
+    </eClassifiers>
+  </eSubpackages>
+  <eSubpackages name="assessment" nsURI="http://daanse.eclipse.org/example/consumer.subpackages/assessment"
+      nsPrefix="assessment">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="basePackage" value="org.eclipse.daanse.example.consumer"/>
+      <details key="prefix" value="Assessment"/>
+    </eAnnotations>
+    <eClassifiers xsi:type="ecore:EClass" name="Assessment">
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="title"
+          eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+      <!-- Sibling-subpackage cross-ref into our own processing/ProcessingRecord
+           (mirrors gdpr's processing<->assessment cross-references) -->
+      <eStructuralFeatures xsi:type="ecore:EReference" name="record"
+          eType="#//processing/ProcessingRecord"/>
+      <!-- Also reference an external nested type to mirror gdpr's mixed pattern -->
+      <eStructuralFeatures xsi:type="ecore:EReference" name="dependency"
+          eType="ecore:EClass http://daanse.eclipse.org/example/nested#//a/b/Beta"/>
+    </eClassifiers>
+  </eSubpackages>
+</ecore:EPackage>

--- a/emf/codegen.maven.example/ecore.dependencies.subpackages.consumer.subpackages/pom.xml
+++ b/emf/codegen.maven.example/ecore.dependencies.subpackages.consumer.subpackages/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.tooling.emf.codegen.maven.example</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>
+    org.eclipse.daanse.tooling.emf.codegen.maven.example.ecore.dependencies.subpackages.consumer.subpackages</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Daanse EMF Codegen Example - Consumer with Subpackages and Cross-Module
+    Nested Reference</name>
+  <description>Regression test for the case where the consumer ecore has its
+    own sub-packages AND references classifiers in nested sub-packages of an
+    external dependency, with sibling-subpackage cross-references inside the
+    consumer (mirrors the cwm.governance.gdpr structure).</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore</artifactId>
+    </dependency>
+    <!-- Provides nested/a/Alpha and nested/a/b/Beta -->
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>
+        org.eclipse.daanse.tooling.emf.codegen.maven.example.ecore.simple.subpackages</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.fennec.emf</groupId>
+      <artifactId>org.eclipse.fennec.emf.osgi.api</artifactId>
+      <version>0.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.fennec.emf</groupId>
+      <artifactId>org.eclipse.fennec.emf.osgi.component</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.daanse</groupId>
+        <artifactId>org.eclipse.daanse.tooling.emf.codegen.maven</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <ecoreFile>model/consumer.ecore</ecoreFile>
+              <basePackage>org.eclipse.daanse.example.consumer</basePackage>
+              <outputDirectory>target/generated-sources/emf</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bndlib</artifactId>
+            <version>7.1.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-sources/emf</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/emf/codegen.maven.example/pom.xml
+++ b/emf/codegen.maven.example/pom.xml
@@ -40,6 +40,7 @@
     <!-- Modules with dependencies (must be built after their dependencies) -->
     <module>ecore.dependencies</module>
     <module>ecore.dependencies.subpackages</module>
+    <module>ecore.dependencies.subpackages.consumer.subpackages</module>
     <module>genmodel.dependencies</module>
   </modules>
 

--- a/emf/codegen.maven/src/main/java/org/eclipse/daanse/tooling/emf/codegen/EmfGenerateMojo.java
+++ b/emf/codegen.maven/src/main/java/org/eclipse/daanse/tooling/emf/codegen/EmfGenerateMojo.java
@@ -40,6 +40,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.emf.codegen.ecore.generator.Generator;
+import org.eclipse.emf.codegen.ecore.genmodel.GenClassifier;
 import org.eclipse.emf.codegen.ecore.genmodel.GenModel;
 import org.eclipse.emf.codegen.ecore.genmodel.GenModelFactory;
 import org.eclipse.emf.codegen.ecore.genmodel.GenModelPackage;
@@ -127,6 +128,18 @@ public class EmfGenerateMojo extends AbstractMojo {
      * Fixed directory path where model files (ecore, genmodel) are placed in the JAR.
      */
     private static final String MODEL_FOLDER = "model";
+
+    /**
+     * Tracks every nsURI this plugin has put into {@link EPackage.Registry#INSTANCE}
+     * across mojo invocations in the same JVM. At the start of each invocation we
+     * remove these entries so that the next module starts with a clean view: its
+     * fresh ResourceSet's package registry no longer reports {@code containsKey=true}
+     * via the delegate for nsURIs registered by an earlier session, and EMF's proxy
+     * resolution can find the freshly loaded EPackages instead of stale ones.
+     * Static so it survives the per-lookup mojo instantiation strategy.
+     */
+    private static final java.util.Set<String> pluginRegisteredNsURIs =
+            java.util.Collections.synchronizedSet(new java.util.HashSet<>());
 
     /**
      * Registry mapping EPackage nsURI to GenPackage for dependency resolution.
@@ -429,8 +442,24 @@ public class EmfGenerateMojo extends AbstractMojo {
                 }
             }
 
+            getLog().info("Before saveGenModelToResources: getGenPackages=" + genModel.getGenPackages().size()
+                    + " usedGenPackages=" + genModel.getUsedGenPackages().size());
+
             // Save the GenModel to resources for inclusion in JAR
             saveGenModelToResources(genModel, ePackage);
+
+            getLog().info("After saveGenModelToResources: getGenPackages=" + genModel.getGenPackages().size()
+                    + " usedGenPackages=" + genModel.getUsedGenPackages().size());
+
+            // Verbose diagnostic — only emitted under -X (debug). Dumps the genmodel's
+            // GenPackage tree and probes every EClassifier referenced from main to
+            // verify it's resolvable. Skips EMF's protected findGenClassifier
+            // (reflective invocation has been seen to perturb XMI parser state for
+            // very large models like CWM).
+            if (getLog().isDebugEnabled()) {
+                debugDumpGenModel(genModel);
+                debugProbeFindGenClassifier(genModel, ePackage);
+            }
 
             // Collect referenced package names (to delete their generated files after
             // generation)
@@ -567,6 +596,24 @@ public class EmfGenerateMojo extends AbstractMojo {
 
         // Clear the genPackageRegistry for a fresh run
         genPackageRegistry.clear();
+
+        // Drop nsURIs this plugin previously registered into the JVM-global
+        // EPackage.Registry.INSTANCE in earlier mojo invocations within the same
+        // Maven session. Without this, ResourceSetImpl#getPackageRegistry()'s
+        // delegation would report containsKey=true for those nsURIs, the local
+        // map would never be populated, and EMF cross-ref resolution would walk
+        // stale EClassifier instances detached from this module's resourceSet —
+        // surfacing as findGenClassifier() == null deep inside codegen.
+        synchronized (pluginRegisteredNsURIs) {
+            if (!pluginRegisteredNsURIs.isEmpty()) {
+                getLog().info("Removing " + pluginRegisteredNsURIs.size()
+                        + " stale nsURIs from EPackage.Registry.INSTANCE (from earlier mojo invocations in this JVM)");
+                for (String nsURI : pluginRegisteredNsURIs) {
+                    EPackage.Registry.INSTANCE.remove(nsURI);
+                }
+                pluginRegisteredNsURIs.clear();
+            }
+        }
 
         resourceSet.getResourceFactoryRegistry().getContentTypeToFactoryMap().put(GenModelPackage.eCONTENT_TYPE,
                 new XMIResourceFactoryImpl());
@@ -745,7 +792,8 @@ public class EmfGenerateMojo extends AbstractMojo {
         // Find referenced external packages (transitively)
         Set<EPackage> referencedPackages = findReferencedExternalPackages(ePackage);
         for (EPackage ref : referencedPackages) {
-            getLog().info("Referenced external package: " + ref.getName() + " (" + ref.getNsURI() + ")");
+            getLog().info("Referenced external package: " + ref.getName() + " (" + ref.getNsURI() + ") with "
+                    + ref.getEClassifiers().size() + " EClassifiers");
         }
 
         // Initialize GenModel with ALL packages (main + referenced) — EMF still
@@ -755,6 +803,22 @@ public class EmfGenerateMojo extends AbstractMojo {
         allPackages.add(ePackage);
         allPackages.addAll(referencedPackages);
         genModel.initialize(allPackages);
+
+        getLog().info("After genModel.initialize, GenPackages count: " + genModel.getGenPackages().size());
+        if (getLog().isDebugEnabled()) {
+            for (GenPackage gp : genModel.getGenPackages()) {
+                EPackage ep = gp.getEcorePackage();
+                getLog().debug("  top-level GenPackage: " + gp.getPackageName() + " ("
+                        + (ep != null ? ep.getNsURI() : "null") + ") classifiers="
+                        + gp.getGenClassifiers().size() + " sub=" + gp.getSubGenPackages().size());
+                for (GenPackage sub : gp.getSubGenPackages()) {
+                    EPackage sep = sub.getEcorePackage();
+                    getLog().debug("      sub GenPackage: " + sub.getPackageName() + " ("
+                            + (sep != null ? sep.getNsURI() : "null") + ") classifiers="
+                            + sub.getGenClassifiers().size());
+                }
+            }
+        }
 
         // Configure referenced GenPackages (indices 1+) and MOVE them from
         // getGenPackages() to getUsedGenPackages() — this prevents EMF from
@@ -1142,12 +1206,24 @@ public class EmfGenerateMojo extends AbstractMojo {
      */
     private void registerEPackage(ResourceSet resourceSet, EPackage ePackage, String source) {
         String nsURI = ePackage.getNsURI();
-        if (nsURI != null && !EPackage.Registry.INSTANCE.containsKey(nsURI)) {
-            EPackage.Registry.INSTANCE.put(nsURI, ePackage);
-            resourceSet.getPackageRegistry().put(nsURI, ePackage);
-            getLog().info("Registered EPackage" + source + ": " + ePackage.getName() + " (" + nsURI + ")");
+        if (nsURI != null) {
+            // Putting into EPackage.Registry.INSTANCE happens only the first time
+            // a session sees this nsURI. The resourceSet.getPackageRegistry() also
+            // gets the freshly loaded ePackage on first encounter. ResourceSet
+            // PackageRegistry delegates to INSTANCE for misses, so subsequent
+            // sessions would otherwise short-circuit on the stale INSTANCE entry.
+            if (!EPackage.Registry.INSTANCE.containsKey(nsURI)) {
+                EPackage.Registry.INSTANCE.put(nsURI, ePackage);
+                pluginRegisteredNsURIs.add(nsURI);
+                resourceSet.getPackageRegistry().put(nsURI, ePackage);
+                getLog().info("Registered EPackage" + source + ": " + ePackage.getName() + " (" + nsURI + ")");
+            }
 
-            // Also create and register a GenPackage if GenModel annotations are present
+            // Populate the per-mojo GenPackage registry independently of the JVM-global
+            // EPackage.Registry. The latter persists across modules in the same Maven
+            // session, so on the second consumer module the outer guard would
+            // short-circuit and leave genPackageRegistry empty — breaking cross-package
+            // codegen lookups (manifests as NPE in getPackageFamilyTreeDependencies).
             if (!genPackageRegistry.containsKey(nsURI)) {
                 GenPackage genPackage = createGenPackageFromEcore(resourceSet, ePackage);
                 if (genPackage != null) {
@@ -1607,6 +1683,126 @@ public class EmfGenerateMojo extends AbstractMojo {
     /**
      * Recursively deletes a directory and all its contents.
      */
+    private void debugDumpGenModel(GenModel genModel) {
+        getLog().debug("==== GenModel state before generation ====");
+        getLog().debug("getGenPackages():");
+        for (GenPackage gp : genModel.getGenPackages()) {
+            dumpGenPackage(gp, "  ");
+        }
+        getLog().debug("getUsedGenPackages():");
+        for (GenPackage gp : genModel.getUsedGenPackages()) {
+            dumpGenPackage(gp, "  ");
+        }
+        getLog().debug("==========================================");
+    }
+
+    private void dumpGenPackage(GenPackage gp, String indent) {
+        EPackage ep = gp.getEcorePackage();
+        String nsURI = ep != null ? ep.getNsURI() : "null";
+        int classifiers = gp.getGenClassifiers().size();
+        Resource res = ep != null ? ep.eResource() : null;
+        getLog().debug(indent + gp.getPackageName() + " (" + nsURI + ") classifiers=" + classifiers
+                + " eResource=" + (res != null ? res.getURI() : "null"));
+        for (GenPackage sub : gp.getSubGenPackages()) {
+            dumpGenPackage(sub, indent + "  ");
+        }
+    }
+
+    private void debugProbeFindGenClassifier(GenModel genModel, EPackage mainEPackage) {
+        getLog().debug("==== Probing findGenClassifier for external EClassifier refs ====");
+        Set<EClassifier> probed = new HashSet<>();
+        probeEPackage(genModel, mainEPackage, probed);
+        getLog().debug("==========================================");
+    }
+
+    private void probeEPackage(GenModel genModel, EPackage ePackage, Set<EClassifier> probed) {
+        String ownNsURI = ePackage.getNsURI();
+        for (EClassifier classifier : ePackage.getEClassifiers()) {
+            if (classifier instanceof EClass eClass) {
+                for (EClass sup : eClass.getESuperTypes()) {
+                    probeOne(genModel, sup, ownNsURI, "supertype of " + eClass.getName(), probed);
+                }
+                for (EStructuralFeature f : eClass.getEStructuralFeatures()) {
+                    EClassifier ft = f.getEType();
+                    if (ft != null) {
+                        probeOne(genModel, ft, ownNsURI, eClass.getName() + "." + f.getName(),
+                                probed);
+                    }
+                }
+            }
+        }
+        for (EPackage sub : ePackage.getESubpackages()) {
+            probeEPackage(genModel, sub, probed);
+        }
+    }
+
+    private void probeOne(GenModel genModel, EClassifier ec, String ownRootNsURI, String origin,
+            Set<EClassifier> probed) {
+        if (!probed.add(ec)) {
+            return;
+        }
+        EPackage ep = ec.getEPackage();
+        String nsURI = ep != null ? ep.getNsURI() : "null";
+        // Manual walk: find a GenClassifier whose getEcoreClassifier() == ec, by name
+        // fallback. This mimics what the EMF codegen does without invoking the
+        // protected findGenClassifier method directly (reflection on it can perturb
+        // the state of large generated packages like CWM during their initial parse).
+        GenPackage manualMatch = null;
+        for (GenPackage gp : genModel.getGenPackages()) {
+            manualMatch = matchClassifier(gp, ec);
+            if (manualMatch != null) {
+                break;
+            }
+        }
+        if (manualMatch == null) {
+            for (GenPackage gp : genModel.getUsedGenPackages()) {
+                manualMatch = matchClassifier(gp, ec);
+                if (manualMatch != null) {
+                    break;
+                }
+            }
+        }
+        getLog().debug("       ref " + origin + " -> " + (ec.getName() == null ? "null" : ec.getName())
+                + " in " + nsURI
+                + " instanceTypeName=" + ec.getInstanceTypeName()
+                + " manualMatch=" + (manualMatch != null ? manualMatch.getPackageName() : "NONE"));
+    }
+
+    private GenPackage matchClassifier(GenPackage gp, EClassifier ec) {
+        EPackage gpEP = gp.getEcorePackage();
+        if (gpEP != null && ec.getEPackage() != null
+                && gpEP.getNsURI().equals(ec.getEPackage().getNsURI())) {
+            for (GenClassifier gc : gp.getGenClassifiers()) {
+                if (gc.getEcoreClassifier() == ec) {
+                    return gp;
+                }
+            }
+            // EClassifier may be a different instance with same name
+            for (GenClassifier gc : gp.getGenClassifiers()) {
+                if (gc.getEcoreClassifier() != null
+                        && ec.getName() != null
+                        && ec.getName().equals(gc.getEcoreClassifier().getName())) {
+                    EClassifier other = gc.getEcoreClassifier();
+                    Resource ecRes = ec.eResource();
+                    Resource otherRes = other.eResource();
+                    getLog().warn("    IDENTITY MISMATCH for " + ec.getName()
+                            + ": ec@" + System.identityHashCode(ec) + " in "
+                            + (ecRes != null ? ecRes.getURI() : "null")
+                            + " vs GenClassifier.ec@" + System.identityHashCode(other)
+                            + " in " + (otherRes != null ? otherRes.getURI() : "null"));
+                    return gp;
+                }
+            }
+        }
+        for (GenPackage sub : gp.getSubGenPackages()) {
+            GenPackage m = matchClassifier(sub, ec);
+            if (m != null) {
+                return m;
+            }
+        }
+        return null;
+    }
+
     private void deleteDirectory(File dir) {
         if (dir.isDirectory()) {
             File[] files = dir.listFiles();


### PR DESCRIPTION
Clear nsURIs this plugin added to EPackage.Registry.INSTANCE at the start
of each mojo invocation so modules don't see stale EPackages via the ResourceSet delegate.

Add diagnostic logging.