### PR TITLE
Fix cross-package EEnum default value emitting _LITERAL suffix

### DIFF
--- a/emf/codegen.maven.example/ecore.enum.consumer/model/enumconsumer.ecore
+++ b/emf/codegen.maven.example/ecore.enum.consumer/model/enumconsumer.ecore
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="enumconsumer"
+    nsURI="http://daanse.eclipse.org/example/enumconsumer" nsPrefix="enumconsumer">
+  <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+    <details key="basePackage" value="org.eclipse.daanse.example.enumconsumer"/>
+    <details key="prefix" value="EnumConsumer"/>
+  </eAnnotations>
+  <!-- Uses AccessKind from the provider ecore as an attribute eType AND as
+       a defaultValueLiteral. The generator emits a static EDEFAULT field
+       like "AccessKind.PUBLIC" for the default value; if the external
+       GenModel's complianceLevel is missing/<JDK50 EMF instead emits
+       "AccessKind.PUBLIC_LITERAL", which does not exist in the modern
+       generated enum class and fails to compile. -->
+  <eClassifiers xsi:type="ecore:EClass" name="Member">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="access"
+        eType="ecore:EEnum http://daanse.eclipse.org/example/enumprovider#//AccessKind"
+        defaultValueLiteral="Public"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="fallbackAccess"
+        eType="ecore:EEnum http://daanse.eclipse.org/example/enumprovider#//AccessKind"
+        defaultValueLiteral="Internal"/>
+  </eClassifiers>
+</ecore:EPackage>

--- a/emf/codegen.maven.example/ecore.enum.consumer/pom.xml
+++ b/emf/codegen.maven.example/ecore.enum.consumer/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.tooling.emf.codegen.maven.example</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>
+    org.eclipse.daanse.tooling.emf.codegen.maven.example.ecore.enum.consumer</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Daanse EMF Codegen Example - EEnum Consumer (cross-package default
+    value)</name>
+  <description>Regression test: an EAttribute typed by an EEnum from a
+    dependency ecore, with a defaultValueLiteral. Reproduces the
+    "cannot find symbol PUBLIC_LITERAL" compile failure seen in xmla.csdl
+    when the external GenModel inherited a stale JDK14 complianceLevel.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>
+        org.eclipse.daanse.tooling.emf.codegen.maven.example.ecore.enum.provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.fennec.emf</groupId>
+      <artifactId>org.eclipse.fennec.emf.osgi.api</artifactId>
+      <version>0.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.fennec.emf</groupId>
+      <artifactId>org.eclipse.fennec.emf.osgi.component</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.daanse</groupId>
+        <artifactId>org.eclipse.daanse.tooling.emf.codegen.maven</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <ecoreFile>model/enumconsumer.ecore</ecoreFile>
+              <basePackage>org.eclipse.daanse.example.enumconsumer</basePackage>
+              <outputDirectory>target/generated-sources/emf</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bndlib</artifactId>
+            <version>7.1.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-sources/emf</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/emf/codegen.maven.example/ecore.enum.provider/model/enumprovider.ecore
+++ b/emf/codegen.maven.example/ecore.enum.provider/model/enumprovider.ecore
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="enumprovider"
+    nsURI="http://daanse.eclipse.org/example/enumprovider" nsPrefix="enumprovider">
+  <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+    <details key="basePackage" value="org.eclipse.daanse.example.enumprovider"/>
+    <details key="prefix" value="EnumProvider"/>
+  </eAnnotations>
+  <eClassifiers xsi:type="ecore:EEnum" name="AccessKind">
+    <eLiterals name="Public"/>
+    <eLiterals name="Internal" value="1"/>
+    <eLiterals name="Private" value="2"/>
+  </eClassifiers>
+</ecore:EPackage>

--- a/emf/codegen.maven.example/ecore.enum.provider/pom.xml
+++ b/emf/codegen.maven.example/ecore.enum.provider/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.tooling.emf.codegen.maven.example</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>
+    org.eclipse.daanse.tooling.emf.codegen.maven.example.ecore.enum.provider</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Daanse EMF Codegen Example - EEnum Provider</name>
+  <description>Provides an EEnum (AccessKind) consumed by ecore.enum.consumer
+    as an attribute default value. Regression coverage for the cross-package
+    EEnumLiteral reference path (legacy "_LITERAL" suffix vs modern Java enum
+    constant).</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.fennec.emf</groupId>
+      <artifactId>org.eclipse.fennec.emf.osgi.api</artifactId>
+      <version>0.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.fennec.emf</groupId>
+      <artifactId>org.eclipse.fennec.emf.osgi.component</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.daanse</groupId>
+        <artifactId>org.eclipse.daanse.tooling.emf.codegen.maven</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <ecoreFile>model/enumprovider.ecore</ecoreFile>
+              <basePackage>org.eclipse.daanse.example.enumprovider</basePackage>
+              <outputDirectory>target/generated-sources/emf</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bndlib</artifactId>
+            <version>7.1.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-sources/emf</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/emf/codegen.maven.example/pom.xml
+++ b/emf/codegen.maven.example/pom.xml
@@ -36,11 +36,13 @@
     <module>ecore.annotated</module>
     <module>ecore.loadpackage</module>
     <module>ecore.noosgi</module>
+    <module>ecore.enum.provider</module>
     <module>genmodel.simple</module>
     <!-- Modules with dependencies (must be built after their dependencies) -->
     <module>ecore.dependencies</module>
     <module>ecore.dependencies.subpackages</module>
     <module>ecore.dependencies.subpackages.consumer.subpackages</module>
+    <module>ecore.enum.consumer</module>
     <module>genmodel.dependencies</module>
   </modules>
 

--- a/emf/codegen.maven/src/main/java/org/eclipse/daanse/tooling/emf/codegen/EmfGenerateMojo.java
+++ b/emf/codegen.maven/src/main/java/org/eclipse/daanse/tooling/emf/codegen/EmfGenerateMojo.java
@@ -852,6 +852,14 @@ public class EmfGenerateMojo extends AbstractMojo {
             // URI during subsequent code-generation.
             GenModel externalModel = GenModelFactory.eINSTANCE.createGenModel();
             externalModel.setModelName("External");
+            // Inherit the main genmodel's complianceLevel. Without this, the new
+            // external GenModel defaults to JDK14, and EMF emits cross-package
+            // EEnumLiteral references in the legacy "<NAME>_LITERAL" form (see
+            // GenEnumLiteralImpl.getEnumLiteralInstanceConstantName, which appends
+            // _LITERAL when complianceLevel < JDK50). The producing module's
+            // generated enum class only has the modern "<NAME>" constant, so
+            // consumer code fails to compile with "cannot find symbol PUBLIC_LITERAL".
+            externalModel.setComplianceLevel(genModel.getComplianceLevel());
             String ecoreName = ecoreFile.getName();
             String baseName = ecoreName.endsWith(".ecore")
                 ? ecoreName.substring(0, ecoreName.length() - 6)
@@ -1573,6 +1581,11 @@ public class EmfGenerateMojo extends AbstractMojo {
             GenModel genModel = GenModelFactory.eINSTANCE.createGenModel();
             genModel.initialize(Collections.singletonList(ePackage));
             genModel.setModelName(capitalize(ePackage.getName()));
+            // Match the main genmodel's complianceLevel (set in createGenModel).
+            // The default JDK14 would trigger legacy "<NAME>_LITERAL" emission for
+            // any cross-package EEnum default values when this synthesized
+            // GenPackage is consumed by another module's generator.
+            genModel.setComplianceLevel(org.eclipse.emf.codegen.ecore.genmodel.GenJDKLevel.JDK170_LITERAL);
 
             // Create a synthetic resource for the GenModel
             URI genModelUri = URI.createURI("synthetic:/" + ePackage.getName() + ".genmodel");


### PR DESCRIPTION
Inherit complianceLevel on the external/synthesized GenModels so EMF doesn't fall back to legacy "<NAME>_LITERAL" enum references. Add an ecore.enum.provider/consumer example reproducing the failure.
